### PR TITLE
Added cylinder and annulus sources and cleaned up slack TODO

### DIFF
--- a/Input.cpp
+++ b/Input.cpp
@@ -281,13 +281,13 @@ void Input::readInput( std::string xmlFilename ) {
       double rad = s.attribute("rad").as_double();
       std::string dir = s.attribute("dir").value();
       if(dir == "x" || dir == "X"){
-        S = std::make_shared< xCylinder > ( name, x0, y0, z0, rad );
+        S = std::make_shared< xCylinder > ( name, y0, z0, rad );
       }
       else if(dir == "y" || dir == "Y"){
-        S = std::make_shared< yCylinder > ( name, x0, y0, z0, rad );
+        S = std::make_shared< yCylinder > ( name, x0, z0, rad );
       }
       else if(dir == "z" || dir == "Z"){
-        S = std::make_shared< zCylinder > ( name, x0, y0, z0, rad );
+        S = std::make_shared< zCylinder > ( name, x0, y0, rad );
       }
     }
     else {
@@ -574,6 +574,108 @@ void Input::readInput( std::string xmlFilename ) {
         throw;
       }
     }
+        else if( type == "setSourceAnnulus" ) {
+      pugi::xml_attribute X0   = so.attribute("xSource");
+      pugi::xml_attribute Y0   = so.attribute("ySource");
+      pugi::xml_attribute Z0   = so.attribute("zSource");
+      pugi::xml_attribute Height = so.attribute("height");
+      pugi::xml_attribute Axis = so.attribute("axis");
+      pugi::xml_attribute Radi = so.attribute("radInner");
+      pugi::xml_attribute Rado = so.attribute("radOuter");
+      std::string dist = so.attribute("distribution").value();
+
+      //Check attributes passed
+      if(!X0 || !Y0 || !Z0 || !Height || !Axis || !Radi || !Rado || Radi.as_double() < 0
+         || Rado.as_double() < 0 || Radi.as_double() > Rado.as_double() || Height.as_double() < 0) {
+        std::cout << " source setSourceCylinder " << name << " initialized incorrectly" << std::endl;
+        throw;
+      }
+
+      double x0   = X0.as_double();
+      double y0   = Y0.as_double();
+      double z0   = Z0.as_double();
+      double height = Height.as_double();
+      std::string axis = Axis.value();
+      double radi = Radi.as_double();
+      double rado = Rado.as_double();
+
+      if ( dist == "hardcoded" ) {
+        // all neutrons come from the first group
+        std::vector< double > sourceGroups;
+        sourceGroups.push_back( 1.0 );
+        for ( int i=1; i<nGroups; i++ ) {
+          sourceGroups.push_back( 0.0 );
+        }
+        if(axis == "x" || axis == "X"){
+          sourc = std::make_shared< setSourceXAnnulus > ( name, x0, y0, z0, height, radi, rado, sourceGroups );
+        }
+        else if(axis == "y" || axis == "Y"){
+          sourc = std::make_shared< setSourceYAnnulus > ( name, x0, y0, z0, height, radi, rado, sourceGroups );
+        }
+        else if(axis == "z" || axis == "Z"){
+          sourc = std::make_shared< setSourceZAnnulus > ( name, x0, y0, z0, height, radi, rado, sourceGroups );
+        }
+        else{
+          std::cout << " unknown axis type with name " << axis << std::endl;
+          throw;
+        }
+        
+      }
+      else {
+        std::cout << " unknown distribution type with name " << dist << std::endl;
+        throw;
+      }
+    }
+    else if( type == "setSourceCylinder" ) {
+      pugi::xml_attribute X0   = so.attribute("xSource");
+      pugi::xml_attribute Y0   = so.attribute("ySource");
+      pugi::xml_attribute Z0   = so.attribute("zSource");
+      pugi::xml_attribute Height = so.attribute("height");
+      pugi::xml_attribute Axis = so.attribute("axis");
+      pugi::xml_attribute Rad = so.attribute("radius");
+      std::string dist = so.attribute("distribution").value();
+
+      //Check attributes passed
+      if(!X0 || !Y0 || !Z0 || !Height || !Axis || !Rad || Rad.as_double() < 0 || Height.as_double() < 0){
+        std::cout << " source setSourceCylinder " << name << " initialized incorrectly" << std::endl;
+        throw;
+      }
+
+      double x0   = so.attribute("xSource").as_double();
+      double y0   = so.attribute("ySource").as_double();
+      double z0   = so.attribute("zSource").as_double();
+      double height = so.attribute("height").as_double();
+      std::string axis = so.attribute("axis").value();
+      double rad = so.attribute("radius").as_double();
+
+      if ( dist == "hardcoded" ) {
+        // all neutrons come from the first group
+        std::vector< double > sourceGroups;
+        sourceGroups.push_back( 1.0 );
+        for ( int i=1; i<nGroups; i++ ) {
+          sourceGroups.push_back( 0.0 );
+        }
+        if(axis == "x" || axis == "X"){
+          sourc = std::make_shared< setSourceXAnnulus > ( name, x0, y0, z0, height, 0, rad, sourceGroups );
+        }
+        else if(axis == "y" || axis == "Y"){
+          sourc = std::make_shared< setSourceYAnnulus > ( name, x0, y0, z0, height, 0, rad, sourceGroups );
+        }
+        else if(axis == "z" || axis == "Z"){
+          sourc = std::make_shared< setSourceZAnnulus > ( name, x0, y0, z0, height, 0, rad, sourceGroups );
+        }
+        else{
+          std::cout << " unknown axis type with name " << axis << std::endl;
+          throw;
+        }
+        
+      }
+      else {
+        std::cout << " unknown distribution type with name " << dist << std::endl;
+        throw;
+      }
+    }
+
     else {
       std::cout << " unnknown source type with name " << type << std::endl;
       throw;

--- a/Source.cpp
+++ b/Source.cpp
@@ -86,3 +86,143 @@ Part_ptr setSourceSphere::sample(){
 	return p;
 
 }
+
+Part_ptr setSourceXAnnulus::sample(){
+	//I dont like rejection sampling for this becuase the inner and outer radii may be 
+	//very similar in some systems - if the radii are close and large it may take a very long
+	//time to actually guess a point in the box on the annulus
+	//However - if a cylinder is passed I do switch to rejection
+
+	double pi = acos(-1.);
+
+	auto group = groupSample(groupProbability);
+
+    //direction sampling	
+    //QUESTION?? Is this any random angle?
+	double mu = 2 * Urand() - 1;
+	double phi = 2 * pi*Urand();
+	double omegaX=mu;
+	double omegaY=sin(acos(mu))*cos(phi);
+	double omegaZ=sin(acos(mu))*sin(phi);
+	point dir = point(omegaX,omegaY,omegaZ);
+
+	double x, y, z;
+	x = height*Urand();
+	if(radInner != 0) {
+		phi = 2 * pi*Urand();
+		double dist = std::sqrt(radInner*radInner + (radOuter*radOuter - radInner*radInner)*Urand());	
+		y = dist*cos(phi);
+		z = dist*sin(phi);
+	}
+	else{
+		bool reject = true;
+		while(reject)
+		{
+			y = 2*Urand()*radOuter;
+			z = 2*Urand()*radOuter;
+			double dist = sqrt(y*y+z*z);
+			if(dist < radOuter)
+				reject = false;
+		}
+	}
+	point pos = point(x,y,z);
+
+    Part_ptr p = std::make_shared<Particle>(pos, dir, group );
+
+	return p;
+
+}
+
+Part_ptr setSourceYAnnulus::sample(){
+	//I dont like rejection sampling for this becuase the inner and outer radii may be 
+	//very similar in some systems - if the radii are close and large it may take a very long
+	//time to actually guess a point in the box on the annulus
+	//However - if a cylinder is passed I do switch to rejection
+
+	double pi = acos(-1.);
+
+	auto group = groupSample(groupProbability);
+
+    //direction sampling	
+	double mu = 2 * Urand() - 1;
+	double phi = 2 * pi*Urand();
+	double omegaX=mu;
+	double omegaY=sin(acos(mu))*cos(phi);
+	double omegaZ=sin(acos(mu))*sin(phi);
+	point dir = point(omegaX,omegaY,omegaZ);
+
+	double x, y, z;
+	y = height*Urand();
+	if(radInner != 0){
+		phi = 2 * pi*Urand();
+		double dist = std::sqrt(radInner*radInner + (radOuter*radOuter - radInner*radInner)*Urand());
+		x = dist*cos(phi);
+		z = dist*sin(phi);
+	}
+	else{
+		bool reject = true;
+		while(reject)
+		{
+			x = 2*Urand()*radOuter;
+			z = 2*Urand()*radOuter;
+			double dist = sqrt(x*x+z*z);
+			if(dist < radOuter)
+				reject = false;
+		}
+	}
+	point pos = point(x,y,z);
+
+    Part_ptr p = std::make_shared<Particle>(pos, dir, group );
+
+	return p;
+
+}
+
+
+Part_ptr setSourceZAnnulus::sample(){
+	//I dont like rejection sampling for this becuase the inner and outer radii may be 
+	//very similar in some systems - if the radii are close and large it may take a very long
+	//time to actually guess a point in the box on the annulus
+	//However - if a cylinder is passed I do switch to rejection
+
+	double pi = acos(-1.);
+
+	auto group = groupSample(groupProbability);
+
+    //direction sampling	
+	double mu = 2 * Urand() - 1;
+	double phi = 2 * pi*Urand();
+	double omegaX=mu;
+	double omegaY=sin(acos(mu))*cos(phi);
+	double omegaZ=sin(acos(mu))*sin(phi);
+	point dir = point(omegaX,omegaY,omegaZ);
+
+	double x,y,z;
+	z = height*Urand();
+	if(radInner != 0){
+		phi = 2 * pi*Urand();
+		double dist = std::sqrt(radInner*radInner + (radOuter*radOuter - radInner*radInner)*Urand());
+		x = dist*cos(phi);
+		y = dist*sin(phi);
+	}
+	else{
+		bool reject = true;
+		while(reject)
+		{
+			x = 2*Urand()*radOuter;
+			y = 2*Urand()*radOuter;
+			double dist = sqrt(x*x+y*y);
+			if(dist < radOuter)
+				reject = false;
+		}
+	}
+	point pos = point(x,y,z);
+
+
+    Part_ptr p = std::make_shared<Particle>(pos, dir, group );
+
+	return p;
+
+}
+
+

--- a/Source.h
+++ b/Source.h
@@ -2,6 +2,7 @@
 #include <vector>
 #include <memory>
 #include <string>
+#include <cassert>
 #include "Particle.h"
 #ifndef _SOURCE_HEADER_
 #define _SOURCE_HEADER_
@@ -40,5 +41,44 @@ public:
    ~setSourceSphere() {};
    Part_ptr sample();
 };
+class setSourceXAnnulus : public Source {
+private:
+   double x0,y0,z0, height, radInner, radOuter;
+   std::vector <double> groupProbability;
+public:
+   setSourceXAnnulus(std::string label, double xSource, double ySource, double zSource, double height_in, double radInner, double radOuter, std::vector<double> groupProbSet )
+   : Source(label), x0(xSource), y0(ySource), z0(zSource), height(height_in), radInner(radInner), radOuter(radOuter), groupProbability(groupProbSet) {
+      assert(height > 0 && radInner >= 0.0 && radOuter > 0);
+   };
+   ~setSourceXAnnulus() {};
+   Part_ptr sample();
+};
+
+class setSourceYAnnulus : public Source {
+private:
+   double x0,y0,z0, height, radInner, radOuter;
+   std::vector <double> groupProbability;
+public:
+   setSourceYAnnulus(std::string label, double xSource, double ySource, double zSource, double height_in, double radInner, double radOuter, std::vector<double> groupProbSet )
+   : Source(label), x0(xSource), y0(ySource), z0(zSource), height(height_in), radInner(radInner), radOuter(radOuter), groupProbability(groupProbSet) {
+      assert(height > 0 && radInner >= 0 && radOuter > 0);
+   };
+   ~setSourceYAnnulus() {};
+   Part_ptr sample();
+};
+
+class setSourceZAnnulus : public Source {
+private:
+   double x0,y0,z0, height, radInner, radOuter;
+   std::vector <double> groupProbability;
+public:
+   setSourceZAnnulus(std::string label, double xSource, double ySource, double zSource, double height_in, double radInner, double radOuter, std::vector<double> groupProbSet )
+   : Source(label), x0(xSource), y0(ySource), z0(zSource), height(height_in), radInner(radInner), radOuter(radOuter), groupProbability(groupProbSet) {
+      assert(height > 0 && radInner >= 0 && radOuter > 0);
+   };
+   ~setSourceZAnnulus() {};
+   Part_ptr sample();
+};
+
 
 #endif

--- a/Surface.cpp
+++ b/Surface.cpp
@@ -100,7 +100,7 @@ double zCylinder::eval( point p ) {
 //Effects: returns the distance from the point p on its path u to the surface
 double xCylinder::distance (point p, point u ) {
   // difference between each coordinate and current point
-  point q( p.x - x0, p.y - y0, p.z - z0 );
+  point q( 0, p.y - y0, p.z - z0 );
 
   //Equ: (y-y0)^2 + (z-z0)^2 - r^2 = s
   double a = ( std::pow(u.y, 2) + std::pow(u.z,2) );
@@ -119,7 +119,7 @@ double xCylinder::distance (point p, point u ) {
 //Effects: returns the distance from the point p on its path u to the surface
 double yCylinder::distance (point p, point u ) {
   // difference between each coordinate and current point
-  point q( p.x - x0, p.y - y0, p.z - z0 );
+  point q( p.x - x0, 0, p.z - z0 );
 
   //Equ: (y-y0)^2 + (z-z0)^2 - r^2 = s
   double a = ( std::pow(u.x, 2) + std::pow(u.z,2) );
@@ -139,7 +139,7 @@ double yCylinder::distance (point p, point u ) {
 //Effects: returns the distance from the point p on its path u to the surface
 double zCylinder::distance (point p, point u ) {
   // difference between each coordinate and current point
-  point q( p.x - x0, p.y - y0, p.z - z0 );
+  point q( p.x - x0, p.y - y0, 0 );
 
   //Equ: (y-y0)^2 + (z-z0)^2 - r^2 = s
   double a = ( std::pow(u.x, 2) + std::pow(u.y,2) );
@@ -162,9 +162,7 @@ point  xCylinder::getNormal( point p ) {
   // check if the crossing point is on the surface
   if(Utility::FloatZero(eval(p))) {
     // the gradient vector of the cylinder, general for all orientations
-    point normal( 2.0*(p.x - x0), 2.0*(p.y - y0), 2.0*(p.z - z0) );
-    
-    normal.x = 0;
+    point normal( 0, 2.0*(p.y - y0), 2.0*(p.z - z0) );
 
     // return the unit normal vector
     return( normal / std::sqrt(normal * normal) );
@@ -184,9 +182,7 @@ point  yCylinder::getNormal( point p ) {
   // check if the crossing point is on the surface
   if(Utility::FloatZero(eval(p))) {
     // the gradient vector of the cylinder, general for all orientations
-    point normal( 2.0*(p.x - x0), 2.0*(p.y - y0), 2.0*(p.z - z0) );
-    
-    normal.y = 0;
+    point normal( 2.0*(p.x - x0), 0, 2.0*(p.z - z0) );
 
     // return the unit normal vector
     return( normal / std::sqrt(normal * normal) );
@@ -206,9 +202,7 @@ point  zCylinder::getNormal( point p ) {
   // check if the crossing point is on the surface
   if(Utility::FloatZero(eval(p))) {
     // the gradient vector of the cylinder, general for all orientations
-    point normal( 2.0*(p.x - x0), 2.0*(p.y - y0), 2.0*(p.z - z0) );
-    
-    normal.z = 0;
+    point normal( 2.0*(p.x - x0), 2.0*(p.y - y0), 0 );
 
     // return the unit normal vector
     return( normal / std::sqrt(normal * normal) );

--- a/Surface.h
+++ b/Surface.h
@@ -66,10 +66,10 @@ public:
 //Currently only takes cylinders along a x/y/z axis
 class xCylinder : public surface {
 private:
-    double x0, y0, z0, rad;
+    double y0, z0, rad;
 public:
-    xCylinder( std::string label, double x_in, double y_in, double z_in, double rad_in)
-            : surface(label), x0(x_in), y0(y_in), z0(z_in), rad(rad_in) { 
+    xCylinder( std::string label, double y_in, double z_in, double rad_in)
+            : surface(label), y0(y_in), z0(z_in), rad(rad_in) { 
         assert(rad > 0);
     };
     ~xCylinder() {};
@@ -81,10 +81,10 @@ public:
 
 class yCylinder : public surface {
 private:
-    double x0, y0, z0, rad;
+    double x0, z0, rad;
 public:
-    yCylinder( std::string label, double x_in, double y_in, double z_in, double rad_in)
-            : surface(label), x0(x_in), y0(y_in), z0(z_in), rad(rad_in) { 
+    yCylinder( std::string label, double x_in, double z_in, double rad_in)
+            : surface(label), x0(x_in), z0(z_in), rad(rad_in) { 
         assert(rad > 0);
     };
     ~yCylinder() {};
@@ -96,10 +96,10 @@ public:
 
 class zCylinder : public surface {
 private:
-    double x0, y0, z0, rad;
+    double x0, y0, rad;
 public:
-    zCylinder( std::string label, double x_in, double y_in, double z_in, double rad_in)
-            : surface(label), x0(x_in), y0(y_in), z0(z_in), rad(rad_in) { 
+    zCylinder( std::string label, double x_in, double y_in, double rad_in)
+            : surface(label), x0(x_in), y0(y_in), rad(rad_in) { 
         assert(rad > 0);
     };
     ~zCylinder() {};

--- a/Testing/cylinder_test.cpp
+++ b/Testing/cylinder_test.cpp
@@ -15,9 +15,9 @@ TEST_CASE( "Cylinder", "[cylinder]" ) {
 
     std::string name = "SimpleXCyl";
 
-    xCylinder SimpleXCyl( name, x0, y0, z0, rad);
-    yCylinder SimpleYCyl( name, x0, y0, z0, rad);
-    zCylinder SimpleZCyl( name, x0, y0, z0, rad);
+    xCylinder SimpleXCyl( name, y0, z0, rad);
+    yCylinder SimpleYCyl( name, x0, z0, rad);
+    zCylinder SimpleZCyl( name, x0, y0, rad);
 
     // test returns appropriate name
     SECTION ( " return surface name " ) {
@@ -159,10 +159,9 @@ TEST_CASE( "Cylinder", "[cylinder]" ) {
     //IDK hown to get around it so this test case will always fail
     x0 = 0;
     y0 = 0;
-    z0 = 0;
     rad = 1;
     std::string n = "forNorm";
-    zCylinder forNorm( n, x0, y0, z0, rad );
+    zCylinder forNorm( n, x0, y0, rad );
 
     SECTION ( " normal vec of cylinder " ) {
 


### PR DESCRIPTION
This modifies Source.h and Source.cpp to handle an annulus source (if the inner rad is zero then it is handled as cylindrical) and Input.cpp to read in the new source. 

Way to pass cylinder <setSourceCylinder name="cylinderSource" distribution="hardcoded" xSource="0.0" ySource="0.0" zSource="0.0" height="4" axis="x" radius="1" >

Way to pass annulus <setSourceAnnulus name="annularSource" distribution="hardcoded" xSource="0.0" ySource="0.0" zSource="0.0" height="4" axis="x" radInner="1" radOuter="2">

Surface.h and Surface.cpp are modified to clean up the TODO in the slack I mentioned, now no coordinates passed by the user on the infinite axis. 

After this pull I think this branch can be deleted